### PR TITLE
Добавить Quick Settings плитку для управления VPN из шторки

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -50,6 +50,18 @@
                       android:value="VPN proxy for secure internet access using xray-core" />
         </service>
 
+        <!-- Quick Settings плитка для управления VPN из шторки -->
+        <service
+            android:name=".VpnTileService"
+            android:exported="true"
+            android:label="TeapodStream VPN"
+            android:icon="@drawable/ic_vpn_tile"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
+        </service>
+
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />

--- a/android/app/src/main/kotlin/com/teapodstream/teapodstream/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/teapodstream/teapodstream/MainActivity.kt
@@ -27,6 +27,9 @@ class MainActivity : FlutterActivity() {
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
 
+        // Инициализируем контекст для обновления Quick Settings плитки
+        VpnEventStreamHandler.appContext = applicationContext
+
         // Event channel for native → Flutter events
         EventChannel(flutterEngine.dartExecutor.binaryMessenger, EVENT_CHANNEL)
             .setStreamHandler(VpnEventStreamHandler)

--- a/android/app/src/main/kotlin/com/teapodstream/teapodstream/VpnEventStreamHandler.kt
+++ b/android/app/src/main/kotlin/com/teapodstream/teapodstream/VpnEventStreamHandler.kt
@@ -1,7 +1,10 @@
 package com.teapodstream.teapodstream
 
+import android.content.ComponentName
+import android.os.Build
 import android.os.Handler
 import android.os.Looper
+import android.service.quicksettings.TileService
 import io.flutter.plugin.common.EventChannel
 
 /**
@@ -11,6 +14,8 @@ import io.flutter.plugin.common.EventChannel
 object VpnEventStreamHandler : EventChannel.StreamHandler {
     private var eventSink: EventChannel.EventSink? = null
     private val handler = Handler(Looper.getMainLooper())
+    // Контекст приложения для обновления Quick Settings плитки
+    @Volatile var appContext: android.content.Context? = null
 
     override fun onListen(arguments: Any?, events: EventChannel.EventSink?) {
         eventSink = events
@@ -32,6 +37,8 @@ object VpnEventStreamHandler : EventChannel.StreamHandler {
 
     fun sendStateEvent(state: String) {
         sendEvent(mapOf("type" to "state", "value" to state))
+        // Обновляем Quick Settings плитку при изменении состояния VPN
+        requestTileUpdate()
     }
 
     fun sendLogEvent(level: String, message: String) {
@@ -53,5 +60,20 @@ object VpnEventStreamHandler : EventChannel.StreamHandler {
                 "downloadSpeed" to downloadSpeed,
             )
         )
+    }
+
+    /**
+     * Запрашивает обновление Quick Settings плитки.
+     */
+    private fun requestTileUpdate() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            val ctx = appContext ?: return
+            try {
+                TileService.requestListeningState(
+                    ctx,
+                    ComponentName(ctx, VpnTileService::class.java)
+                )
+            } catch (_: Exception) { }
+        }
     }
 }

--- a/android/app/src/main/kotlin/com/teapodstream/teapodstream/VpnTileService.kt
+++ b/android/app/src/main/kotlin/com/teapodstream/teapodstream/VpnTileService.kt
@@ -1,0 +1,84 @@
+package com.teapodstream.teapodstream
+
+import android.content.Intent
+import android.os.Build
+import android.service.quicksettings.Tile
+import android.service.quicksettings.TileService
+import androidx.annotation.RequiresApi
+
+/**
+ * Quick Settings плитка для управления VPN из шторки уведомлений.
+ * Позволяет включать/выключать VPN одним нажатием.
+ */
+@RequiresApi(Build.VERSION_CODES.N)
+class VpnTileService : TileService() {
+
+    override fun onStartListening() {
+        super.onStartListening()
+        updateTile()
+    }
+
+    override fun onClick() {
+        super.onClick()
+        val currentState = XrayVpnService.getNativeState()
+
+        if (currentState == "connected" || currentState == "connecting") {
+            // Отключаем VPN
+            val intent = Intent(this, XrayVpnService::class.java).apply {
+                action = XrayVpnService.ACTION_DISCONNECT
+            }
+            startService(intent)
+        } else {
+            // Открываем приложение для подключения (нужен выбор конфига)
+            val launchIntent = packageManager.getLaunchIntentForPackage(packageName)
+            launchIntent?.apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                putExtra("action", "connect")
+            }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                startActivityAndCollapse(
+                    android.app.PendingIntent.getActivity(
+                        this@VpnTileService, 0, launchIntent!!,
+                        android.app.PendingIntent.FLAG_UPDATE_CURRENT or android.app.PendingIntent.FLAG_IMMUTABLE
+                    )
+                )
+            } else {
+                @Suppress("DEPRECATION")
+                startActivityAndCollapse(launchIntent)
+            }
+        }
+    }
+
+    /**
+     * Обновляет состояние плитки в соответствии с текущим состоянием VPN.
+     */
+    private fun updateTile() {
+        val tile = qsTile ?: return
+        val vpnState = XrayVpnService.getNativeState()
+
+        when (vpnState) {
+            "connected" -> {
+                tile.state = Tile.STATE_ACTIVE
+                tile.label = "VPN включён"
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    tile.subtitle = "Нажмите для отключения"
+                }
+            }
+            "connecting" -> {
+                tile.state = Tile.STATE_ACTIVE
+                tile.label = "VPN"
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    tile.subtitle = "Подключение..."
+                }
+            }
+            else -> {
+                tile.state = Tile.STATE_INACTIVE
+                tile.label = "VPN выключен"
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    tile.subtitle = "Нажмите для включения"
+                }
+            }
+        }
+        tile.updateTile()
+    }
+}

--- a/android/app/src/main/kotlin/com/teapodstream/teapodstream/VpnTileService.kt
+++ b/android/app/src/main/kotlin/com/teapodstream/teapodstream/VpnTileService.kt
@@ -1,6 +1,7 @@
 package com.teapodstream.teapodstream
 
 import android.content.Intent
+import android.net.VpnService
 import android.os.Build
 import android.service.quicksettings.Tile
 import android.service.quicksettings.TileService
@@ -29,23 +30,46 @@ class VpnTileService : TileService() {
             }
             startService(intent)
         } else {
-            // Открываем приложение для подключения (нужен выбор конфига)
-            val launchIntent = packageManager.getLaunchIntentForPackage(packageName)
-            launchIntent?.apply {
-                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                putExtra("action", "connect")
+            // Подключаем VPN из сохранённого конфига
+            val vpnIntent = VpnService.prepare(this)
+            if (vpnIntent != null) {
+                // Нет разрешения VPN — открываем приложение для его запроса
+                openApp()
+                return
             }
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-                startActivityAndCollapse(
-                    android.app.PendingIntent.getActivity(
-                        this@VpnTileService, 0, launchIntent!!,
-                        android.app.PendingIntent.FLAG_UPDATE_CURRENT or android.app.PendingIntent.FLAG_IMMUTABLE
-                    )
-                )
+
+            val connectIntent = XrayVpnService.createConnectIntentFromSaved(this)
+            if (connectIntent != null) {
+                // Есть сохранённый конфиг — подключаемся напрямую
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    startForegroundService(connectIntent)
+                } else {
+                    startService(connectIntent)
+                }
             } else {
-                @Suppress("DEPRECATION")
-                startActivityAndCollapse(launchIntent)
+                // Нет сохранённого конфига — открываем приложение для выбора
+                openApp()
             }
+        }
+    }
+
+    /** Открывает приложение (fallback, если нет конфига или разрешения). */
+    private fun openApp() {
+        val launchIntent = packageManager.getLaunchIntentForPackage(packageName)
+        launchIntent?.apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            putExtra("action", "connect")
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            startActivityAndCollapse(
+                android.app.PendingIntent.getActivity(
+                    this@VpnTileService, 0, launchIntent!!,
+                    android.app.PendingIntent.FLAG_UPDATE_CURRENT or android.app.PendingIntent.FLAG_IMMUTABLE
+                )
+            )
+        } else {
+            @Suppress("DEPRECATION")
+            startActivityAndCollapse(launchIntent)
         }
     }
 

--- a/android/app/src/main/kotlin/com/teapodstream/teapodstream/XrayVpnService.kt
+++ b/android/app/src/main/kotlin/com/teapodstream/teapodstream/XrayVpnService.kt
@@ -65,6 +65,58 @@ class XrayVpnService : VpnService() {
             "downloadSpeed" to lastDownloadSpeed,
         )
 
+        private const val PREFS_NAME = "vpn_tile_prefs"
+
+        /** Сохраняет параметры последнего подключения для Quick Settings плитки. */
+        fun saveLastConnectionParams(
+            context: android.content.Context,
+            xrayConfig: String, socksPort: Int, socksUser: String, socksPassword: String,
+            excludedPackages: List<String>, includedPackages: List<String>,
+            vpnMode: String, tunAddress: String, tunNetmask: String, tunMtu: Int, tunDns: String,
+        ) {
+            context.getSharedPreferences(PREFS_NAME, android.content.Context.MODE_PRIVATE).edit()
+                .putString("xrayConfig", xrayConfig)
+                .putInt("socksPort", socksPort)
+                .putString("socksUser", socksUser)
+                .putString("socksPassword", socksPassword)
+                .putStringSet("excludedPackages", excludedPackages.toSet())
+                .putStringSet("includedPackages", includedPackages.toSet())
+                .putString("vpnMode", vpnMode)
+                .putString("tunAddress", tunAddress)
+                .putString("tunNetmask", tunNetmask)
+                .putInt("tunMtu", tunMtu)
+                .putString("tunDns", tunDns)
+                .putBoolean("hasConfig", true)
+                .apply()
+        }
+
+        /** Проверяет, есть ли сохранённый конфиг для Quick Settings плитки. */
+        fun hasLastConnectionParams(context: android.content.Context): Boolean {
+            return context.getSharedPreferences(PREFS_NAME, android.content.Context.MODE_PRIVATE)
+                .getBoolean("hasConfig", false)
+        }
+
+        /** Создаёт Intent для подключения VPN из сохранённых параметров. */
+        fun createConnectIntentFromSaved(context: android.content.Context): Intent? {
+            val prefs = context.getSharedPreferences(PREFS_NAME, android.content.Context.MODE_PRIVATE)
+            if (!prefs.getBoolean("hasConfig", false)) return null
+
+            return Intent(context, XrayVpnService::class.java).apply {
+                action = ACTION_CONNECT
+                putExtra(EXTRA_XRAY_CONFIG, prefs.getString("xrayConfig", "") ?: "")
+                putExtra(EXTRA_SOCKS_PORT, prefs.getInt("socksPort", 10808))
+                putExtra(EXTRA_SOCKS_USER, prefs.getString("socksUser", "") ?: "")
+                putExtra(EXTRA_SOCKS_PASSWORD, prefs.getString("socksPassword", "") ?: "")
+                putExtra(EXTRA_EXCLUDED_PACKAGES, ArrayList(prefs.getStringSet("excludedPackages", emptySet()) ?: emptySet()))
+                putExtra(EXTRA_INCLUDED_PACKAGES, ArrayList(prefs.getStringSet("includedPackages", emptySet()) ?: emptySet()))
+                putExtra(EXTRA_VPN_MODE, prefs.getString("vpnMode", "allExcept") ?: "allExcept")
+                putExtra(EXTRA_TUN_ADDRESS, prefs.getString("tunAddress", "10.0.0.1") ?: "10.0.0.1")
+                putExtra(EXTRA_TUN_NETMASK, prefs.getString("tunNetmask", "255.255.255.0") ?: "255.255.255.0")
+                putExtra(EXTRA_TUN_MTU, prefs.getInt("tunMtu", 1500))
+                putExtra(EXTRA_TUN_DNS, prefs.getString("tunDns", "1.1.1.1") ?: "1.1.1.1")
+            }
+        }
+
         fun prepareBinaries(context: android.content.Context): Boolean {
             val abi = android.os.Build.SUPPORTED_ABIS.firstOrNull() ?: "arm64-v8a"
             val filesDir = context.filesDir
@@ -111,6 +163,11 @@ class XrayVpnService : VpnService() {
             val tunNetmask = intent.getStringExtra(EXTRA_TUN_NETMASK) ?: "255.255.255.0"
             val tunMtu = intent.getIntExtra(EXTRA_TUN_MTU, 1500)
             val tunDns = intent.getStringExtra(EXTRA_TUN_DNS) ?: "1.1.1.1"
+
+            // Сохраняем параметры подключения для Quick Settings плитки
+            saveLastConnectionParams(this, xrayConfig, socksPort, socksUser, socksPassword,
+                excludedPackages, includedPackages, vpnMode, tunAddress, tunNetmask, tunMtu, tunDns)
+
             startVpn(xrayConfig, socksPort, socksUser, socksPassword,
                 excludedPackages, includedPackages, vpnMode,
                 tunAddress, tunNetmask, tunMtu, tunDns)
@@ -280,6 +337,13 @@ class XrayVpnService : VpnService() {
         } catch (_: IllegalThreadStateException) {
             true   // still running
         }
+    }
+
+    override fun onRevoke() {
+        // Вызывается Android, когда VPN отключен извне (системные настройки, другой VPN)
+        log("info", "VPN revoked by system")
+        stopVpn()
+        stopSelf()
     }
 
     private fun stopVpn() {

--- a/android/app/src/main/res/drawable/ic_vpn_tile.xml
+++ b/android/app/src/main/res/drawable/ic_vpn_tile.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M12,1L3,5v6c0,5.55 3.84,10.74 9,12 5.16,-1.26 9,-6.45 9,-12V5L12,1zM12,11.99h7c-0.53,4.12 -3.28,7.79 -7,8.94V12H5V6.3l7,-3.11v8.8z" />
+</vector>


### PR DESCRIPTION
Добавлена плитка Quick Settings (TileService) для быстрого включения/выключения VPN прямо из шторки уведомлений Android. Включает иконку, обработку состояний и регистрацию в манифесте.