### PR TITLE
Сортировать отмеченные приложения в начало списка

### DIFF
--- a/lib/ui/screens/split_tunnel_screen.dart
+++ b/lib/ui/screens/split_tunnel_screen.dart
@@ -181,6 +181,14 @@ class _SplitTunnelScreenState extends ConsumerState<SplitTunnelScreen> {
                             a.packageName.toLowerCase().contains(_search))
                         .toList();
 
+                // Отмеченные приложения — в начало списка
+                filtered.sort((a, b) {
+                  final aSelected = packages.contains(a.packageName);
+                  final bSelected = packages.contains(b.packageName);
+                  if (aSelected != bSelected) return aSelected ? -1 : 1;
+                  return a.appName.compareTo(b.appName);
+                });
+
                 return ListView.builder(
                   padding: const EdgeInsets.only(bottom: 24),
                   itemCount: filtered.length,


### PR DESCRIPTION
Исправляет #6

Отмеченные (включённые/исключённые) приложения теперь отображаются в начале списка, а не перемешаны по алфавиту. Внутри каждой группы (отмеченные / остальные) сохраняется алфавитная сортировка.