### PR TITLE
Добавить поддержку транспортов xhttp, httpupgrade, splithttp

### DIFF
--- a/lib/core/models/vpn_config.dart
+++ b/lib/core/models/vpn_config.dart
@@ -4,7 +4,7 @@ enum VpnProtocol { vless, vmess, trojan, shadowsocks }
 
 enum VpnSecurity { none, tls, reality }
 
-enum VpnTransport { tcp, ws, grpc, http2, quic }
+enum VpnTransport { tcp, ws, grpc, http2, quic, xhttp, httpupgrade, splithttp }
 
 class VpnConfig {
   final String id;

--- a/lib/protocols/xray/vless_parser.dart
+++ b/lib/protocols/xray/vless_parser.dart
@@ -249,6 +249,12 @@ class VlessParser {
         return VpnTransport.http2;
       case 'quic':
         return VpnTransport.quic;
+      case 'xhttp':
+        return VpnTransport.xhttp;
+      case 'httpupgrade':
+        return VpnTransport.httpupgrade;
+      case 'splithttp':
+        return VpnTransport.splithttp;
       default:
         return VpnTransport.tcp;
     }

--- a/lib/protocols/xray/xray_config_builder.dart
+++ b/lib/protocols/xray/xray_config_builder.dart
@@ -178,6 +178,24 @@ class XrayConfigBuilder {
         'grpcSettings': {
           'serviceName': config.grpcServiceName ?? '',
         },
+      if (config.transport == VpnTransport.xhttp)
+        'xhttpSettings': {
+          'path': config.wsPath ?? '/',
+          if (config.wsHost != null && config.wsHost!.isNotEmpty)
+            'host': config.wsHost,
+        },
+      if (config.transport == VpnTransport.splithttp)
+        'splithttpSettings': {
+          'path': config.wsPath ?? '/',
+          if (config.wsHost != null && config.wsHost!.isNotEmpty)
+            'host': config.wsHost,
+        },
+      if (config.transport == VpnTransport.httpupgrade)
+        'httpupgradeSettings': {
+          'path': config.wsPath ?? '/',
+          if (config.wsHost != null && config.wsHost!.isNotEmpty)
+            'host': config.wsHost,
+        },
     };
   }
 

--- a/lib/ui/widgets/config_card.dart
+++ b/lib/ui/widgets/config_card.dart
@@ -44,6 +44,9 @@ class ConfigCard extends StatelessWidget {
         VpnTransport.http2 => 'H2',
         VpnTransport.quic => 'QUIC',
         VpnTransport.tcp => 'TCP',
+        VpnTransport.xhttp => 'XHTTP',
+        VpnTransport.httpupgrade => 'HTTPUpgrade',
+        VpnTransport.splithttp => 'SplitHTTP',
       };
 
   @override


### PR DESCRIPTION
Исправлена проблема, при которой конфиг VLESS+REALITY+XHTTP определялся как TCP. Причина: транспорт xhttp отсутствовал в enum VpnTransport, парсер URI возвращал fallback tcp, а билдер конфига не генерировал xhttpSettings.

Изменения:
- Добавлены значения xhttp, httpupgrade, splithttp в VpnTransport
- Добавлен парсинг этих транспортов в VlessParser._parseTransport()
- Добавлена генерация xhttpSettings, splithttpSettings, httpupgradeSettings в XrayConfigBuilder._buildStreamSettings()
- Добавлено отображение новых транспортов в UI (config_card.dart)

Closes https://github.com/Wendor/teapod-stream/issues/10